### PR TITLE
change package installs to use ensure => present to be compatible gcc module

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -4,38 +4,38 @@
 #
 class rbenv::deps::debian {
   if ! defined(Package['build-essential']) {
-    package { 'build-essential': ensure => installed }
+    package { 'build-essential': ensure => present }
   }
 
   if ! defined(Package['libreadline6-dev']) {
-    package { 'libreadline6-dev': ensure => installed }
+    package { 'libreadline6-dev': ensure => present }
   }
 
   if ! defined(Package['libssl-dev']) {
-    package { 'libssl-dev': ensure => installed }
+    package { 'libssl-dev': ensure => present }
   }
 
   if ! defined(Package['zlib1g-dev']) {
-    package { 'zlib1g-dev': ensure => installed }
+    package { 'zlib1g-dev': ensure => present }
   }
 
   if ! defined(Package['libffi-dev']) {
-    package { 'libffi-dev': ensure => installed }
+    package { 'libffi-dev': ensure => present }
   }
 
   if ! defined(Package['libyaml-dev']) {
-    package { 'libyaml-dev': ensure => installed }
+    package { 'libyaml-dev': ensure => present }
   }
 
   if ! defined(Package['libncurses5-dev']) {
-    package { 'libncurses5-dev': ensure => installed }
+    package { 'libncurses5-dev': ensure => present }
   }
 
   if ! defined(Package['libgdbm3']) {
-    package { 'libgdbm3': ensure => installed }
+    package { 'libgdbm3': ensure => present }
   }
 
   if ! defined(Package['libgdbm-dev']) {
-    package { 'libgdbm-dev': ensure => installed }
+    package { 'libgdbm-dev': ensure => present }
   }
 }

--- a/manifests/deps/redhat.pp
+++ b/manifests/deps/redhat.pp
@@ -4,46 +4,46 @@
 #
 class rbenv::deps::redhat {
   if ! defined(Package['binutils']) {
-    package { 'binutils': ensure => installed }
+    package { 'binutils': ensure => present }
   }
 
   if ! defined(Package['gcc']) {
-    package { 'gcc': ensure => installed }
+    package { 'gcc': ensure => present }
   }
 
   if ! defined(Package['gcc-c++']) {
-    package { 'gcc-c++': ensure => installed }
+    package { 'gcc-c++': ensure => present }
   }
 
   if ! defined(Package['make']) {
-    package { 'make': ensure => installed }
+    package { 'make': ensure => present }
   }
 
   if ! defined(Package['openssl-devel']) {
-    package { 'openssl-devel': ensure => installed }
+    package { 'openssl-devel': ensure => present }
   }
 
   if ! defined(Package['readline-devel']) {
-    package { 'readline-devel': ensure => installed }
+    package { 'readline-devel': ensure => present }
   }
 
   if ! defined(Package['zlib-devel']) {
-    package { 'zlib-devel': ensure => installed }
+    package { 'zlib-devel': ensure => present }
   }
 
   if ! defined(Package['libffi-devel']) {
-    package { 'libffi-devel': ensure => installed }
+    package { 'libffi-devel': ensure => present }
   }
 
   if ! defined(Package['libyaml-devel']) {
-    package { 'libyaml-devel': ensure => installed }
+    package { 'libyaml-devel': ensure => present }
   }
 
   if ! defined(Package['ncurses-devel']) {
-    package { 'ncurses-devel': ensure => installed }
+    package { 'ncurses-devel': ensure => present }
   }
 
   if ! defined(Package['gdbm-devel']) {
-    package { 'gdbm-devel': ensure => installed }
+    package { 'gdbm-devel': ensure => present }
   }
 }

--- a/manifests/deps/suse.pp
+++ b/manifests/deps/suse.pp
@@ -4,42 +4,42 @@
 #
 class rbenv::deps::suse {
   if ! defined(Package['binutils']) {
-    package { 'binutils': ensure => installed }
+    package { 'binutils': ensure => present }
   }
 
   if ! defined(Package['gcc']) {
-    package { 'gcc': ensure => installed }
+    package { 'gcc': ensure => present }
   }
 
   if ! defined(Package['automake']) {
-    package { 'automake': ensure => installed }
+    package { 'automake': ensure => present }
   }
 
   if ! defined(Package['openssl-devel']) {
-    package { 'openssl-devel': ensure => installed }
+    package { 'openssl-devel': ensure => present }
   }
 
   if ! defined(Package['zlib-devel']) {
-    package { 'zlib-devel': ensure => installed }
+    package { 'zlib-devel': ensure => present }
   }
 
   if ! defined(Package['libffi-devel']) {
-    package { 'libffi-dev': ensure => installed }
+    package { 'libffi-dev': ensure => present }
   }
 
   if ! defined(Package['libyaml-devel']) {
-    package { 'libyaml-dev': ensure => installed }
+    package { 'libyaml-dev': ensure => present }
   }
 
   if ! defined(Package['ncurses-devel']) {
-    package { 'ncurses-dev': ensure => installed }
+    package { 'ncurses-dev': ensure => present }
   }
 
   if ! defined(Package['readline-devel']) {
-    package { 'readline-dev': ensure => installed }
+    package { 'readline-dev': ensure => present }
   }
 
   if ! defined(Package['gdbm-devel']) {
-    package { 'gdbm-dev': ensure => installed }
+    package { 'gdbm-dev': ensure => present }
   }
 }


### PR DESCRIPTION
Previously package installs used ensure => installed though valid this caused conflicts when the same dependancies where declared in the puppetlabs-gcc module see https://github.com/puppetlabs/puppetlabs-gcc/blob/master/manifests/init.pp#L17

stdlib module uses ensure => present as default options for its ensure_packages function, if the same package has already been defined with the same options then it skips redeclaring otherwise it attempts to redeclare the package which results in Duplicate declaration errors.

see https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/lib/puppet/parser/functions/ensure_packages.rb

Because rbenv was using ensure => installed instead of ensure => present gcc was attempting to redeclare the build-essential package on ubuntu